### PR TITLE
Add busloc TripUpdates to feed options

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Downloads archived MBTA real-time data feeds from various sources.
 | `--stop [stop id]`    | Use to only include trip_updates affecting the given (comma-separated) stop_id(s)             |
 | `--route [route id]`  | Use to only include trip_updates affecting the given route                                    |
 | `--trip [trip id]`    | Use to only include a specific trip_id                                                        |
-| `--feed [name]`       | Feed to retrieve. Accepted values: `bus` (default), `subway`, `cr`, `cr_vehicle`, `cr_boarding`, `winthrop`, `concentrate`, `concentrate_vehicle`, `alerts`, `busloc_vehicle`, `swiftly_bus_vehicle` |
+| `--feed [name]`       | Feed to retrieve. Accepted values: `bus` (default), `subway`, `cr`, `cr_vehicle`, `cr_boarding`, `winthrop`, `concentrate`, `concentrate_vehicle`, `alerts`, `busloc`, `busloc_vehicle`, `swiftly_bus_vehicle` |
 | `--raw`               | Download the file directly, without filtering or processing                                   |
 | `--output [filepath]` | Where to create the output file (default is `prediction-loc/output/[feed]-[datetime].json`)   |
 

--- a/scripts/getArchive.py
+++ b/scripts/getArchive.py
@@ -28,6 +28,7 @@ FEED_TO_KEY_MAPPING = {
     "concentrate_vehicle": [["concentrate_VehiclePositions_enhanced"],
                             ["realtime_VehiclePositions_enhanced"]],
     "alerts": [["Alerts_enhanced"]],
+    "busloc": [["busloc", "TripUpdates"]],
     "busloc_vehicle": [["busloc", "VehiclePositions"]],
     "swiftly_bus_vehicle": [["goswift.ly", "mbta_bus", "vehicle_positions"]]
 }


### PR DESCRIPTION
This allows easily downloading the feed `busloc` generates from block waivers.