### PR TITLE
feat: allow setting custom prefix for object key

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,15 @@ Downloads archived MBTA real-time data feeds from various sources.
 
 ### Optional arguments
 
-|        Argument       |                                          Description                                          |
-| --------------------- | --------------------------------------------------------------------------------------------- |
-| `--stop [stop id]`    | Use to only include trip_updates affecting the given (comma-separated) stop_id(s)             |
-| `--route [route id]`  | Use to only include trip_updates affecting the given route                                    |
-| `--trip [trip id]`    | Use to only include a specific trip_id                                                        |
-| `--feed [name]`       | Feed to retrieve. Accepted values: `bus` (default), `subway`, `cr`, `cr_vehicle`, `cr_boarding`, `winthrop`, `concentrate`, `concentrate_vehicle`, `alerts`, `busloc`, `busloc_vehicle`, `swiftly_bus_vehicle` |
-| `--raw`               | Download the file directly, without filtering or processing                                   |
-| `--output [filepath]` | Where to create the output file (default is `prediction-loc/output/[feed]-[datetime].json`)   |
+|        Argument           |                                          Description                                          |
+| ------------------------- | --------------------------------------------------------------------------------------------- |
+| `--stop [stop id]`        | Use to only include trip_updates affecting the given (comma-separated) stop_id(s)             |
+| `--route [route id]`      | Use to only include trip_updates affecting the given route                                    |
+| `--trip [trip id]`        | Use to only include a specific trip_id                                                        |
+| `--feed [name]`           | Feed to retrieve. Accepted values: `bus` (default), `subway`, `cr`, `cr_vehicle`, `cr_boarding`, `winthrop`, `concentrate`, `concentrate_vehicle`, `alerts`, `busloc`, `busloc_vehicle`, `swiftly_bus_vehicle` |
+| `--raw`                   | Download the file directly, without filtering or processing                                   |
+| `--output [filepath]`     | Where to create the output file (default is `prediction-loc/output/[feed]-[datetime].json`)   |
+| `--object-prefix [prefix]`| Specify a custom prefix for the key of the object to load from S3                             |
 
 **Note:** route_id is matched exactly for the `bus` and `concentrate` feeds, but does substring matching for all others. For example, `--route Green` will include all Green Line branches, and `--route Worcester` will still match route_id `CR-Worcester`.
 

--- a/scripts/getArchive.py
+++ b/scripts/getArchive.py
@@ -160,7 +160,7 @@ parser.add_argument(
 )
 parser.add_argument(
      "--object-prefix",
-    dest="object-prefix",
+    dest="object_prefix",
     help="Specify a custom prefix for the key of the object to load from S3",
 )
 args = vars(parser.parse_args())
@@ -187,8 +187,8 @@ if not args["output"]:
             os.mkdir("../output/")
         args["output"] = "../output/{0}-{1}.json".format(args["feed"], args["datetime"])
 
-if args["object-prefix"]:
-    OBJECT_PREFIX_FORMAT = args["object-prefix"] + "/" + OBJECT_PREFIX_FORMAT
+if args["object_prefix"]:
+    OBJECT_PREFIX_FORMAT = args["object_prefix"] + "/" + OBJECT_PREFIX_FORMAT
 elif not args["feed"].startswith("concentrate"):
     OBJECT_PREFIX_FORMAT = "concentrate/" + OBJECT_PREFIX_FORMAT
 

--- a/scripts/getArchive.py
+++ b/scripts/getArchive.py
@@ -10,7 +10,7 @@ from google.transit import gtfs_realtime_pb2
 from protobuf_to_dict import protobuf_to_dict
 
 OBJECT_PREFIX_FORMAT = (
-    "concentrate/{0}/{1:02d}/{2:02d}/{0:02d}-{1:02d}-{2:02d}T{3:02d}:{4:02d}"
+    "{0}/{1:02d}/{2:02d}/{0:02d}-{1:02d}-{2:02d}T{3:02d}:{4:02d}"
 )
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M"
 LOCAL_TIMEZONE = pytz.timezone("US/Eastern")
@@ -158,6 +158,11 @@ parser.add_argument(
     default="bus",
     help='Feed to retrieve. Defaults to "bus"',
 )
+parser.add_argument(
+     "--object-prefix",
+    dest="object-prefix",
+    help="Specify a custom prefix for the key of the object to load from S3",
+)
 args = vars(parser.parse_args())
 
 dateTime = LOCAL_TIMEZONE.localize(
@@ -182,8 +187,10 @@ if not args["output"]:
             os.mkdir("../output/")
         args["output"] = "../output/{0}-{1}.json".format(args["feed"], args["datetime"])
 
-if args["feed"].startswith("concentrate"):
-    OBJECT_PREFIX_FORMAT = OBJECT_PREFIX_FORMAT[12:]
+if args["object-prefix"]:
+    OBJECT_PREFIX_FORMAT = args["object-prefix"] + "/" + OBJECT_PREFIX_FORMAT
+elif not args["feed"].startswith("concentrate"):
+    OBJECT_PREFIX_FORMAT = "concentrate/" + OBJECT_PREFIX_FORMAT
 
 outputfile = os.path.expanduser(args["output"])
 with open(outputfile, "w") as file:
@@ -214,7 +221,7 @@ with open(outputfile, "w") as file:
                     feed_obj.ParseFromString(response.content)
                     feed = protobuf_to_dict(feed_obj)
                 feed["header"]["timestamp"] = unix_to_local_string(
-                    feed["header"]["timestamp"]
+                    int(feed["header"]["timestamp"])
                 )
                 feed["entity"] = [
                     convert_timestamps(e)


### PR DESCRIPTION
Also fixes issue with not correctly parsing when the timestamp in the feed header is a string representation of an integer rather than integer.

This is to support some Skate research where we want to look at historical Swiftly test data, which is stored under its own object prefix. I figured I would make it an option rather than hardcoding something about this situation, given that it's temporary.