### PR TITLE
feat: use ISO 8601

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Downloads archived MBTA real-time data feeds from various sources.
 
 ## Usage
 
-`pipenv run getArchive --datetime [YYYY-MM-DDTHH:mm]`
+`poetry run prediction-loc --datetime (date -Iminutes -d 'last Fri')`
+`poetry run prediction-loc --datetime (date -Iminutes -d 'last Fri')`
 
 ### Optional arguments
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,38 @@ Downloads archived MBTA real-time data feeds from various sources.
 
 ## Usage
 
-`poetry run prediction-loc --datetime (date -Iminutes -d 'last Fri')`
-`poetry run prediction-loc --datetime (date -Iminutes -d 'last Fri')`
+```
+poetry run prediction-loc --datetime 2023-04-04T04:04-04:00
+
+# When specified without timezone information,
+# this will attempt to guess/use your local timezone
+poetry run prediction-loc --datetime 2023-04-04T04:04
+```
+
+You can also use utilities which generate `ISO 8601` & `ISO 3339` formatted datetimes such as `date`.
+
+Depending on the source of your `date` binary, the syntax may look a bit different
+
+For instance, `date` from `GNU coreutils` has a `-Iminutes` to specify `ISO 8601` format, 
+and the `-d` flag which accepts a wide range of inputs documented on 
+[GNU Date Input Formats Documentation](https://www.gnu.org/software/coreutils/manual/html_node/Date-input-formats.html)
+Among other options https://www.gnu.org/software/coreutils/manual/html_node/Options-for-date.html
+```
+poetry run prediction-loc --datetime $(date -Iminutes -d '04/04 04:04')
+poetry run prediction-loc --datetime $(date -Iminutes -d 'last Fri')
+```
+
+
+Whereas on macOS, which uses `date` from BSD land, also has `-Iminutes` for 
+`ISO 8601` format, but uses the `-v` flag to set the date (which is documented at 
+the [FreeBSD `date` command manual page](https://man.freebsd.org/cgi/man.cgi?date)
+or via `man date` on macOS)
+```
+poetry run prediction-loc --datetime $(date -Iminutes -v 04m -v 04d -v 04H -v 04M)
+
+# One month and one day ago
+poetry run prediction-loc --datetime $(date -Iminutes -v -1m -v -1d)
+```
 
 ### Optional arguments
 

--- a/README.md
+++ b/README.md
@@ -30,11 +30,12 @@ Downloads archived MBTA real-time data feeds from various sources.
 ## Usage
 
 ```
-poetry run prediction-loc --datetime 2023-04-04T04:04-04:00
+pipenv run getArchive --datetime [YYYY-MM-DDTHH:mm]
+pipenv run prediction-loc --datetime 2023-04-04T04:04-04:00
 
 # When specified without timezone information,
 # this will attempt to guess/use your local timezone
-poetry run prediction-loc --datetime 2023-04-04T04:04
+pipenv run prediction-loc --datetime 2023-04-04T04:04
 ```
 
 You can also use utilities which generate [`ISO 8601` & `ISO 3339`](https://ijmacd.github.io/rfc3339-iso8601/) formatted datetimes such as `date`.
@@ -46,8 +47,8 @@ and the `-d` flag which accepts a wide range of inputs documented on
 [GNU Date Input Formats Documentation](https://www.gnu.org/software/coreutils/manual/html_node/Date-input-formats.html)
 Among other options https://www.gnu.org/software/coreutils/manual/html_node/Options-for-date.html
 ```
-poetry run prediction-loc --datetime $(date -Iminutes -d '04/04 04:04')
-poetry run prediction-loc --datetime $(date -Iminutes -d 'last Fri')
+pipenv run prediction-loc --datetime $(date -Iminutes -d '04/04 04:04')
+pipenv run prediction-loc --datetime $(date -Iminutes -d 'last Fri')
 ```
 
 
@@ -56,10 +57,10 @@ Whereas on macOS, which uses `date` from BSD land, also has `-Iminutes` for
 the [FreeBSD `date` command manual page](https://man.freebsd.org/cgi/man.cgi?date)
 or via `man date` on macOS)
 ```
-poetry run prediction-loc --datetime $(date -Iminutes -v 04m -v 04d -v 04H -v 04M)
+pipenv run prediction-loc --datetime $(date -Iminutes -v 04m -v 04d -v 04H -v 04M)
 
 # One month and one day ago
-poetry run prediction-loc --datetime $(date -Iminutes -v -1m -v -1d)
+pipenv run prediction-loc --datetime $(date -Iminutes -v -1m -v -1d)
 ```
 
 ### Optional arguments

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ Downloads archived MBTA real-time data feeds from various sources.
 
 ```
 pipenv run getArchive --datetime [YYYY-MM-DDTHH:mm]
-pipenv run prediction-loc --datetime 2023-04-04T04:04-04:00
+pipenv run getArchive --datetime 2023-04-04T04:04-04:00
 
 # When specified without timezone information,
 # this will attempt to guess/use your local timezone
-pipenv run prediction-loc --datetime 2023-04-04T04:04
+pipenv run getArchive --datetime 2023-04-04T04:04
 ```
 
 You can also use utilities which generate [`ISO 8601` & `ISO 3339`](https://ijmacd.github.io/rfc3339-iso8601/) formatted datetimes such as `date`.
@@ -47,8 +47,8 @@ and the `-d` flag which accepts a wide range of inputs documented on
 [GNU Date Input Formats Documentation](https://www.gnu.org/software/coreutils/manual/html_node/Date-input-formats.html)
 Among other options https://www.gnu.org/software/coreutils/manual/html_node/Options-for-date.html
 ```
-pipenv run prediction-loc --datetime $(date -Iminutes -d '04/04 04:04')
-pipenv run prediction-loc --datetime $(date -Iminutes -d 'last Fri')
+pipenv run getArchive --datetime $(date -Iminutes -d '04/04 04:04')
+pipenv run getArchive --datetime $(date -Iminutes -d 'last Fri')
 ```
 
 
@@ -57,10 +57,10 @@ Whereas on macOS, which uses `date` from BSD land, also has `-Iminutes` for
 the [FreeBSD `date` command manual page](https://man.freebsd.org/cgi/man.cgi?date)
 or via `man date` on macOS)
 ```
-pipenv run prediction-loc --datetime $(date -Iminutes -v 04m -v 04d -v 04H -v 04M)
+pipenv run getArchive --datetime $(date -Iminutes -v 04m -v 04d -v 04H -v 04M)
 
 # One month and one day ago
-pipenv run prediction-loc --datetime $(date -Iminutes -v -1m -v -1d)
+pipenv run getArchive --datetime $(date -Iminutes -v -1m -v -1d)
 ```
 
 ### Optional arguments

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ poetry run prediction-loc --datetime 2023-04-04T04:04-04:00
 poetry run prediction-loc --datetime 2023-04-04T04:04
 ```
 
-You can also use utilities which generate `ISO 8601` & `ISO 3339` formatted datetimes such as `date`.
+You can also use utilities which generate [`ISO 8601` & `ISO 3339`](https://ijmacd.github.io/rfc3339-iso8601/) formatted datetimes such as `date`.
 
 Depending on the source of your `date` binary, the syntax may look a bit different
 

--- a/scripts/getArchive.py
+++ b/scripts/getArchive.py
@@ -125,7 +125,7 @@ parser.add_argument(
     "--datetime",
     dest="datetime",
     required=True,
-    help="Datetime of desired archive file, in format {YYYY}-{MM}-{DD}T{HH}:{mm}",
+    help="Datetime of desired archive file, in ISO 8601 & 3339 formats ({YYYY}-{MM}-{DD}T{HH}:{mm}-{utc_tz_offset}?)",
 )
 parser.add_argument(
     "-o", "--output", dest="output", help="Location for where to place the output file"
@@ -165,9 +165,7 @@ parser.add_argument(
 )
 args = vars(parser.parse_args())
 
-dateTime = LOCAL_TIMEZONE.localize(
-    datetime.strptime(args["datetime"], DATETIME_FORMAT)
-).astimezone(pytz.utc)
+dateTime = datetime.fromisoformat(args["datetime"]).astimezone(pytz.utc)
 
 feed_type_choices = FEED_TO_KEY_MAPPING[args["feed"]]
 if args["stops"]:


### PR DESCRIPTION
This allows usage of utilities like `date` to generate time strings and makes interop easier by consuming ISO 8601 strings.

---

Please feel free to add any other reviewers you might think should take a look at this :)