### PR TITLE
fix: fix --feed concentrate runtime None error

### DIFF
--- a/scripts/getArchive.py
+++ b/scripts/getArchive.py
@@ -39,6 +39,8 @@ def bucket_object_prefix_format_string(args):
         return f'{args["object_prefix"]}/{OBJECT_PREFIX_FORMAT}'
     elif not args["feed"].startswith("concentrate"):
         return f"concentrate/{OBJECT_PREFIX_FORMAT}"
+    else:
+        return OBJECT_PREFIX_FORMAT
 
 def matches_filters(ent, args):
     trip = entity_trip(ent)


### PR DESCRIPTION
Fixes a bug from https://github.com/mbta/prediction_loc/commit/6794d20b2da6805adb0609d689a6dec887ee9357 where OBJECT_PREFIX_FORMAT was removed as a default value

without the default, if `args["object_prefix"]` isn't used and `args["feed"].startswith("concentrate")`, it threw a runtime error about a NoneType, 

```
Traceback (most recent call last):
  File "/Users/mharty/git/prediction_loc/scripts/getArchive.py", line 238, in <module>
    main(parse_args())
  File "/Users/mharty/git/prediction_loc/scripts/getArchive.py", line 202, in main
    prefix = bucket_object_prefix_format_string(args).format(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'format'
```